### PR TITLE
Reuse requirements.txt to complete PyJWT switch

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst LICENSE.rst CHANGES.rst
+include requirements.txt README.rst LICENSE.rst CHANGES.rst
 recursive-include docs *
 recursive-exclude docs *.pyc
 recursive-exclude docs *.pyo

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,8 @@ if "sdist" in sys.argv and not os.path.exists("./docs/_themes/README"):
 here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, 'README.rst')) as f:
     readme = f.read()
+with io.open(os.path.join(here, 'requirements.txt')) as f:
+    requirements = f.read().split()
 
 setup(
     name='flask-oidc',
@@ -30,13 +32,8 @@ setup(
     version='1.4.0',
     packages=[
         'flask_oidc',
-    ],
-    install_requires=[
-        'Flask',
-        'itsdangerous',
-        'oauth2client',
-        'six',
-    ],
+    ],  
+    install_requires=requirements,
     tests_require=['nose', 'mock'],
     entry_points={
         'console_scripts': ['oidc-register=flask_oidc.registration_util:main'],


### PR DESCRIPTION
This removes duplication and pulls in the itsdangerous -> PyJWT change into setup.py